### PR TITLE
Dependencias con maven-compiler-plugin y maven-release-plugin actualizadas

### DIFF
--- a/afirma-lib-itext-android/pom.xml
+++ b/afirma-lib-itext-android/pom.xml
@@ -87,17 +87,17 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.6.1</version>
+				<version>${maven-compiler-plugin.version}</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>${jdk.version}</source>
+					<target>${jdk.version}</target>
 				</configuration>
 			</plugin>
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>2.5.2</version>
+				<version>2.5.3</version>
 				<configuration>
 					<tagNameFormat>${project.name}_@{project.version}</tagNameFormat>
 				</configuration>

--- a/afirma-lib-jmimemagic/pom.xml
+++ b/afirma-lib-jmimemagic/pom.xml
@@ -72,10 +72,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
+				<version>${maven-compiler-plugin.version}</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>${jdk.version}</source>
+					<target>${jdk.version}</target>
 				</configuration>
 			</plugin>
 

--- a/afirma-lib-juniversalchardet/pom.xml
+++ b/afirma-lib-juniversalchardet/pom.xml
@@ -58,10 +58,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
+				<version>${maven-compiler-plugin.version}</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>${jdk.version}</source>
+					<target>${jdk.version}</target>
 				</configuration>
 			</plugin>
 

--- a/afirma-lib-oro/pom.xml
+++ b/afirma-lib-oro/pom.xml
@@ -49,10 +49,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
+				<version>${maven-compiler-plugin.version}</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>${jdk.version}</source>
+					<target>${jdk.version}</target>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
Actualizadas dependencias de los plugins `maven-compiler-plugin` y `maven-release-plugin` en todos los módulos.
Arregla #10 